### PR TITLE
Remove duplicate console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
     install_requires=requirements,
     entry_points={
         'console_scripts': [
-            'apachetomcatscanner=apachetomcatscanner.__main__:main',
             'ApacheTomcatScanner=apachetomcatscanner.__main__:main'
         ]
     }


### PR DESCRIPTION
This creates a duplicate script on case insensitive file systems, and [`installer`](https://installer.pypa.io/en/stable/), unlike `pip`, will refuse to install this wheel. I'm unsure of the origin of having both scripts, so this PR could be optimistic: I'd be willing to consider other approaches.