### PR TITLE
[bugfix] Fix bug where provided credentials are not tested

### DIFF
--- a/apachetomcatscanner/Config.py
+++ b/apachetomcatscanner/Config.py
@@ -66,17 +66,15 @@ class Config(object):
             f.close()
 
         if len(usernames) != 0 and len(passwords) != 0:
-            self.credentials = {"credentials": []}
+            self.credentials = []
             for username in usernames:
                 for password in passwords:
-                    self.credentials["credentials"].append({
+                    self.credentials.append({
                         "username": username,
                         "password": password,
                         "description": ""
                     })
-            return True
-        else:
-            return False
+        return len(self.credentials)
 
     # Get / Set functions
 

--- a/apachetomcatscanner/__main__.py
+++ b/apachetomcatscanner/__main__.py
@@ -213,6 +213,7 @@ def main():
 
     config = Config()
     config.set_debug_mode(options.debug)
+    config.set_verbose_mode(options.verbose)
     config.set_no_colors(options.no_colors)
     config.set_request_available_schemes(only_http=options.only_http, only_https=options.only_https)
     config.set_request_timeout(options.request_timeout)

--- a/apachetomcatscanner/__main__.py
+++ b/apachetomcatscanner/__main__.py
@@ -223,7 +223,9 @@ def main():
     config.set_list_cves_mode(options.list_cves)
     config.set_show_cves_descriptions_mode(options.show_cves_descriptions)
 
-    config.load_credentials_from_options(options.tomcat_username, options.tomcat_password, options.tomcat_usernames_file, options.tomcat_passwords_file)
+    number_of_tested_credentials = config.load_credentials_from_options(options.tomcat_username, options.tomcat_password, options.tomcat_usernames_file, options.tomcat_passwords_file)
+    if config.verbose_mode:
+        print("[verbose] %s credentials will be tested per target" % number_of_tested_credentials)
 
     vulns_db = VulnerabilitiesDB(config=config)
     reporter = Reporter(config=config, vulns_db=vulns_db)

--- a/apachetomcatscanner/utils/scan.py
+++ b/apachetomcatscanner/utils/scan.py
@@ -91,7 +91,7 @@ def get_version_from_malformed_http_request(url, config):
         return None
 
 
-def try_default_credentials(url_manager, config):
+def try_credentials(url_manager, config):
     found_credentials = []
     try:
         for credentials in config.credentials:
@@ -112,7 +112,7 @@ def try_default_credentials(url_manager, config):
                 found_credentials.append((r.status_code, credentials))
         return found_credentials
     except Exception as e:
-        config.debug("Error in get_version_from_malformed_http_request('%s'): %s " % (url_manager, e))
+        config.debug(f"Error : {e} ")
         return found_credentials
 
 
@@ -155,7 +155,7 @@ def process_url(scheme, target, port, url, config, reporter):
         if result["manager_accessible"]:
             config.debug("Manager is accessible")
             # Test for default credentials
-            credentials_found = try_default_credentials(url_manager, config)
+            credentials_found = try_credentials(url_manager, config)
 
         reporter.report_result(target, port, result, credentials_found)
 


### PR DESCRIPTION
Hi! 
I was trying this tool during assessment and it appears that provided credentials are not tested and silently ignored because of a try/catch. This PR contains:
- **A fix for the problem** : Now the provided credentials are tested if provided through `--tomcat-usernames-file`, `--tomcat-passwords-file`, `--tomcat-username` or `--tomcat-password`. Only the provided credentials are test if they are provided, otherwise only the defaults are tested.
- **Add verbose mode** : Verbose mode was present in argument and config but was not linked, thus not usable. Now the number of tested credentials is printed in verbose mode.

Happy pentesting,

TOLF