### PR TITLE
[bugfix] Fix dependencies issue

### DIFF
--- a/apachetomcatscanner/__main__.py
+++ b/apachetomcatscanner/__main__.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from sectools.network.domains import is_fqdn
 from sectools.network.ip import (expand_cidr, expand_port_range, is_ipv4_addr,
                                  is_ipv4_cidr, is_ipv6_addr)
-from sectools.windows.ldap.ldap import (get_computers_from_domain,
+from sectools.windows.ldap.wrappers import (get_computers_from_domain,
                                    get_servers_from_domain, get_subnets)
 
 from apachetomcatscanner.Config import Config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "sectools>=1.3.10",
+    "sectools>=1.5.0",
     "xlsxwriter",
     "urllib3==1.26.16",
-    "requests==2.29.0"
+    "requests==2.29.0",
+    "ldap3"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sectools>=1.5.0
 xlsxwriter
 urllib3<2
 requests==2.29.0
+ldap3


### PR DESCRIPTION
This PR fix dependencies issue when pulling and installing the code through virtualenv or pipx.

There is still one issue left, regarding the `sectools` dependencies, the latest commit has not been integrated in a pypi release that is necessary for the tool to work, thus the PR should be updated to require the new version once its released.
